### PR TITLE
including the actual exception, as part of the 'onShutdown' notification payload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 vendor
 composer.lock
+.idea/

--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -27,20 +27,20 @@ class ErrorHandler
         switch ($code) {
             case E_NOTICE:
             case E_USER_NOTICE:
-                $exc = new Errors\Notice($message, $file, $line, debug_backtrace());
+                $exc = new Errors\Notice($message, $file, $line, debug_backtrace(), $code);
                 break;
             case E_WARNING:
             case E_USER_WARNING:
-                $exc = new Errors\Warning($message, $file, $line, debug_backtrace());
+                $exc = new Errors\Warning($message, $file, $line, debug_backtrace(), $code);
                 break;
             case E_ERROR:
             case E_CORE_ERROR:
             case E_RECOVERABLE_ERROR:
-                $exc = new Errors\Fatal($message, $file, $line, debug_backtrace());
+                $exc = new Errors\Fatal($message, $file, $line, debug_backtrace(), $code);
                 break;
             case E_USER_ERROR:
             default:
-                $exc = new Errors\Error($message, $file, $line, debug_backtrace());
+                $exc = new Errors\Error($message, $file, $line, debug_backtrace(), $code);
         }
         $this->notifier->notify($exc);
     }
@@ -67,7 +67,7 @@ class ErrorHandler
         if ($error['type'] & error_reporting() === 0) {
          return;
         }
-        $exc = new Errors\Fatal($error['message'], $error['file'], $error['line']);
+        $exc = new Errors\Fatal($error['message'], $error['file'], $error['line'], $trace = array(), $error['type']);
         $this->notifier->notify($exc);
     }
 

--- a/src/Errors/Base.php
+++ b/src/Errors/Base.php
@@ -10,13 +10,15 @@ class Base
   private $file;
   private $line;
   private $trace;
+  private $code;
 
-  public function __construct($message, $file, $line, $trace = array())
+  public function __construct($message, $file, $line, $trace = array(), $code = null)
   {
     $this->message = $message;
     $this->file = $file;
     $this->line = $line;
     $this->trace = $trace;
+    $this->code = $code;
   }
 
   public function getMessage()
@@ -37,5 +39,10 @@ class Base
   public function getTrace()
   {
     return $this->trace;
+  }
+
+  public function getCode()
+  {
+    return $this->code;
   }
 }

--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -73,6 +73,7 @@ class Notifier
             'type' => get_class($exc),
             'message' => $exc->getMessage(),
             'backtrace' => $backtrace,
+            'code' => $exc->getCode(),
         );
 
         $context = array(


### PR DESCRIPTION
attn @sfgeorge,

abandoned original idea of passing the exception into the notification.  as it turns out, the notification is meant to mimic an Exception, so made more sense to pass the error code instead.  this way we'd simply use the `getCode` method that the Exception interface expects.