### PR TITLE
Fix backtrace unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - hhvm
 
 install:
-  - composer install
+  - composer --dev install
 
 script:
-  - phpunit
+  - ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,14 @@
+language: php
+php:
+  - '5.3'
+  - '5.4'
+  - '5.5'
+  - '5.6'
+  - '7.0'
+  - hhvm
+
+install:
+  - composer install
+
+script:
+  - phpunit

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -39,13 +39,14 @@ class NotifyTest extends PHPUnit_Framework_TestCase
     public function testPostsBacktrace()
     {
         $backtrace = $this->notifier->notice['errors'][0]['backtrace'];
+        // Note: The following assertion is specific to PHPUnit 4.8.35
         $wanted = array(array(
             'file' => dirname(dirname(__FILE__)) . '/vendor/phpunit/phpunit/src/Framework/TestCase.php',
-            'line' => 742,
+            'line' => 764,
             'function' => 'Airbrake\Tests\NotifyTest->setUp',
         ));
         for ($i = 0; $i < count($wanted); $i++) {
-            $this->assertEquals($backtrace[$i], $wanted[$i]);
+            $this->assertEquals($wanted[$i], $backtrace[$i]);
         }
     }
 


### PR DESCRIPTION
```
.....F.....

Time: 73 ms, Memory: 5.25MB

There was 1 failure:

1) Airbrake\Tests\NotifyTest::testPostsBacktrace
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
     'file' => '/Users/sgeorge/Code/ifbyphone...se.php'
-    'line' => 764
+    'line' => 742
     'function' => 'Airbrake\Tests\NotifyTest->setUp'
 )

phpbrake/tests/NotifierTest.php:48

FAILURES!
Tests: 11, Assertions: 17, Failures: 1.
```