### PR TITLE
DTPORTAL-2922 log warnings part 2 of 4: fix shutdown handler

### DIFF
--- a/src/ErrorHandler.php
+++ b/src/ErrorHandler.php
@@ -64,8 +64,8 @@ class ErrorHandler
         if ($error === null) {
             return;
         }
-        if ($error['type'] & error_reporting() === 0) {
-         return;
+        if (($error['type'] & \error_reporting()) === 0) {
+            return;
         }
         $exc = new Errors\Fatal($error['message'], $error['file'], $error['line'], $trace = array(), $error['type']);
         $this->notifier->notify($exc);


### PR DESCRIPTION
Cherry-pick the fix from airbrake/phpbrake#45, which ensures that the shutdown handler only acts on errors matching the error_reporting() setting, as intended.