### PR TITLE
DTPORTAL-2922 Part 1 of 4: fix phpbrake test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+dist: trusty
+sudo: false
+
 language: php
 php:
   - '5.3'

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: false
 
 language: php
 php:
-  - '5.3'
   - '5.4'
   - '5.5'
   - '5.6'


### PR DESCRIPTION
fix the phpbrake test suite:

> [HHVM is no longer supported on Ubuntu Precise. Please consider using Trusty with `dist: trusty`.
](https://travis-ci.org/cloudvox/phpbrake/jobs/243389734)