### PR TITLE
STORY-9590 [LegacyDT][AirBrake/PhpBrake] Update AirBrake API endpoint host to `static`

### DIFF
--- a/src/Notifier.php
+++ b/src/Notifier.php
@@ -23,7 +23,7 @@ class Notifier
     {
         // TODO: test that projectId and projectKey exists
         $this->opt = array_merge($opt, array(
-            'host' => 'api.airbrake.io',
+            'host' => 'static.airbrake.io',
         ));
     }
 

--- a/tests/NotifierTest.php
+++ b/tests/NotifierTest.php
@@ -24,7 +24,7 @@ class NotifyTest extends PHPUnit_Framework_TestCase
     {
         $this->assertEquals(
             $this->notifier->url,
-            'https://api.airbrake.io/api/v3/projects/1/notices?key=api_key'
+            'https://static.airbrake.io/api/v3/projects/1/notices?key=api_key'
         );
     }
 


### PR DESCRIPTION
## [STORY-9590 [LegacyDT][AirBrake/PhpBrake] Update AirBrake API endpoint host to `static`](https://ringrevenue.atlassian.net/browse/STORY-9590)
As an engineer, I’d like to configure airbrake implementations to utilize airbrake’s static host (with a statically assigned and allowed IP), rather than their dynamic hosts (with dynamic and likely not allowed IPs), so that API requests from the data center succeed in reaching airbrake.io.

Our data center allow list includes the static IP addresses of Airbrake’s static.airbrake.io API host.  In order to ensure that reporting to Airbrake is not disrupted by the frequently changing IP addresses of Airbrake’s dynamic api.airbrake.io endpoints (since they fall outside our data center’s allow list), we must update our references from *.airbrake.io to static.airbrake.io.

## Requires
No pre-requisites

## Changes
Change host from `api.airbrake.io` to `static.airbrake.io`.

## Reviewer
@gfaza @BMTTMC 

